### PR TITLE
Fix: sort as per transacted at

### DIFF
--- a/app/Filament/Concerns/IncomeExpenseResourceTrait.php
+++ b/app/Filament/Concerns/IncomeExpenseResourceTrait.php
@@ -136,6 +136,7 @@ trait IncomeExpenseResourceTrait
                     ->multiple()
                     ->preload(),
             ], FiltersLayout::AboveContentCollapsible)
+            ->defaultSort('transacted_at')
             ->actions([
                 EditAction::make(),
                 DeleteAction::make(),

--- a/app/Filament/Resources/TransferResource.php
+++ b/app/Filament/Resources/TransferResource.php
@@ -123,6 +123,7 @@ class TransferResource extends Resource
                     ->multiple()
                     ->preload(),
             ], FiltersLayout::AboveContentCollapsible)
+            ->defaultSort('transacted_at')
             ->actions([
                 EditAction::make(),
                 DeleteAction::make(),

--- a/tests/Feature/Expense/ExpenseListSortTest.php
+++ b/tests/Feature/Expense/ExpenseListSortTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Filament\Resources\ExpenseResource;
+use App\Models\Expense;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    Carbon::setTestNow(Carbon::now()->setDay(20)); // ensure default monthly filter does not exclude results
+
+    Expense::factory()->for($this->user)->create([
+        'description' => 'expense 15',
+        'transacted_at' => now()->setDay(15),
+    ]);
+
+    Expense::factory()->for($this->user)->create([
+        'description' => 'expense 5',
+        'transacted_at' => now()->setDay(5),
+    ]);
+
+    Expense::factory()->for($this->user)->create([
+        'description' => 'expense 10',
+        'transacted_at' => now()->setDay(10),
+    ]);
+});
+
+it('sorts expenses list page using transacted_at by default', function () {
+    Expense::factory()->for($this->user)->create();
+
+    $this->get(ExpenseResource::getUrl('index'))->assertSeeTextInOrder([
+        'expense 5', 'expense 10', 'expense 15',
+    ]);
+});

--- a/tests/Feature/Income/IncomeListSortTest.php
+++ b/tests/Feature/Income/IncomeListSortTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Filament\Resources\IncomeResource;
+use App\Models\Income;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    Carbon::setTestNow(Carbon::now()->setDay(20)); // ensure default monthly filter does not exclude results
+
+    Income::factory()->for($this->user)->create([
+        'description' => 'income 15',
+        'transacted_at' => now()->setDay(15),
+    ]);
+
+    Income::factory()->for($this->user)->create([
+        'description' => 'income 5',
+        'transacted_at' => now()->setDay(5),
+    ]);
+
+    Income::factory()->for($this->user)->create([
+        'description' => 'income 10',
+        'transacted_at' => now()->setDay(10),
+    ]);
+});
+
+it('sorts incomes list page using transacted_at by default', function () {
+    Income::factory()->for($this->user)->create();
+
+    $this->get(IncomeResource::getUrl('index'))->assertSeeTextInOrder([
+        'income 5', 'income 10', 'income 15',
+    ]);
+});

--- a/tests/Feature/Transfer/TransferListSortTest.php
+++ b/tests/Feature/Transfer/TransferListSortTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Filament\Resources\TransferResource;
+use App\Models\Transfer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    Carbon::setTestNow(Carbon::now()->setDay(20)); // ensure default monthly filter does not exclude results
+
+    Transfer::factory()->for($this->user)->create([
+        'description' => 'transfer 15',
+        'transacted_at' => now()->setDay(15),
+    ]);
+
+    Transfer::factory()->for($this->user)->create([
+        'description' => 'transfer 5',
+        'transacted_at' => now()->setDay(5),
+    ]);
+
+    Transfer::factory()->for($this->user)->create([
+        'description' => 'transfer 10',
+        'transacted_at' => now()->setDay(10),
+    ]);
+});
+
+it('sorts expenses list page using transacted_at by default', function () {
+    Transfer::factory()->for($this->user)->create();
+
+    $this->get(TransferResource::getUrl('index'))->assertSeeTextInOrder([
+        'transfer 5', 'transfer 10', 'transfer 15',
+    ]);
+});


### PR DESCRIPTION
The default sort was happening on id, now set to `transacted_at`