### PR TITLE
Fix TagImporter and Add CategoryImporter Functionality

### DIFF
--- a/app/Filament/Imports/CategoryImporter.php
+++ b/app/Filament/Imports/CategoryImporter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\Category;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\Models\Import;
+
+class CategoryImporter extends Importer
+{
+    protected static ?string $model = Category::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('name')
+                ->requiredMapping()
+                ->rules(['required', 'max:255']),
+        ];
+    }
+
+    public function resolveRecord(): ?Category
+    {
+        return Category::firstOrNew([
+            'name' => $this->data['name'],
+        ]);
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = 'Your category import has completed and '.number_format($import->successful_rows).' '.str('row')->plural($import->successful_rows).' imported.';
+
+        if ($failedRowsCount = $import->getFailedRowsCount()) {
+            $body .= ' '.number_format($failedRowsCount).' '.str('row')->plural($failedRowsCount).' failed to import.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Imports/TagImporter.php
+++ b/app/Filament/Imports/TagImporter.php
@@ -36,12 +36,9 @@ class TagImporter extends Importer
 
     public function resolveRecord(): ?Tag
     {
-        // return Tag::firstOrNew([
-        //     // Update existing records, matching them by `$this->data['column_name']`
-        //     'email' => $this->data['email'],
-        // ]);
-
-        return new Tag;
+        return Tag::firstOrNew([
+            'name' => $this->data['name'],
+        ]);
     }
 
     public static function getCompletedNotificationBody(Import $import): string

--- a/app/Filament/Resources/CategoryResource/Pages/ListCategories.php
+++ b/app/Filament/Resources/CategoryResource/Pages/ListCategories.php
@@ -3,10 +3,12 @@
 namespace App\Filament\Resources\CategoryResource\Pages;
 
 use App\Filament\Exports\CategoryExporter;
+use App\Filament\Imports\CategoryImporter;
 use App\Filament\Resources\CategoryResource;
 use Filament\Actions\CreateAction;
 use Filament\Actions\ExportAction;
 use Filament\Actions\Exports\Enums\ExportFormat;
+use Filament\Actions\ImportAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListCategories extends ListRecords
@@ -17,6 +19,8 @@ class ListCategories extends ListRecords
     {
         return [
             CreateAction::make(),
+            ImportAction::make()
+                ->importer(CategoryImporter::class),
             ExportAction::make()
                 ->exporter(CategoryExporter::class)
                 ->formats([


### PR DESCRIPTION
---

**Description:**
- Updated the `resolveRecord` method in `TagImporter` to use `firstOrNew` based on the tag's name.
- Introduced a `CategoryImporter` class with validation for importing categories.
- Updated the `ListCategories` page to include an `ImportAction` for easy category data importation.