### PR TITLE
feat: projected cash flow dashboard widget

### DIFF
--- a/app/Enums/Frequency.php
+++ b/app/Enums/Frequency.php
@@ -2,8 +2,8 @@
 
 namespace App\Enums;
 
+use Carbon\Carbon;
 use Filament\Support\Contracts\HasLabel;
-use Illuminate\Support\Carbon;
 
 enum Frequency: string implements HasLabel
 {

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\Widgets;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Form;
@@ -23,5 +24,13 @@ class Dashboard extends BaseDashboard
                     ])
                     ->columns(2),
             ]);
+    }
+
+    public function getWidgets(): array
+    {
+        return [
+            Widgets\IncomeChart::class,
+            Widgets\ExpenseChart::class,
+        ];
     }
 }

--- a/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
+++ b/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
@@ -13,8 +13,6 @@ class RecurringCashFlowOverviewDashboard extends BaseDashboard
 
     protected static ?string $title = 'Recurring CashFlow Overview';
 
-    protected static ?string $navigationIcon = 'heroicon-o-chart-pie';
-
     public function getWidgets(): array
     {
         return [

--- a/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
+++ b/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
@@ -9,7 +9,7 @@ class RecurringCashFlowOverviewDashboard extends BaseDashboard
 {
     protected static ?string $navigationGroup = 'Recurring Transactions';
 
-    protected static string $routePath = 'recurring/overview';
+    protected static string $routePath = 'recurring-overview';
 
     protected static ?string $title = 'Recurring CashFlow Overview';
 

--- a/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
+++ b/app/Filament/Pages/RecurringCashFlowOverviewDashboard.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Filament\Widgets;
+use Filament\Pages\Dashboard as BaseDashboard;
+
+class RecurringCashFlowOverviewDashboard extends BaseDashboard
+{
+    protected static ?string $navigationGroup = 'Recurring Transactions';
+
+    protected static string $routePath = 'recurring/overview';
+
+    protected static ?string $title = 'Recurring CashFlow Overview';
+
+    protected static ?string $navigationIcon = 'heroicon-o-chart-pie';
+
+    public function getWidgets(): array
+    {
+        return [
+            Widgets\RecurringCashFlowOverviewWidget::class,
+        ];
+    }
+}

--- a/app/Filament/Widgets/RecurringCashFlowOverviewWidget.php
+++ b/app/Filament/Widgets/RecurringCashFlowOverviewWidget.php
@@ -27,10 +27,12 @@ class RecurringCashFlowOverviewWidget extends BaseWidget
 
         $disposableIncome = $totalIncomes - $totalExpenses;
 
+        $symbol = config('penny.currency_symbol');
+
         return [
-            Stat::make('Total Estimated Incomes', number_format($totalIncomes)),
-            Stat::make('Total Estimated Expenses', number_format($totalExpenses)),
-            Stat::make('Estimated Disposable Income', number_format($disposableIncome)),
+            Stat::make('Total Estimated Incomes', $symbol.' '.number_format($totalIncomes)),
+            Stat::make('Total Estimated Expenses', $symbol.' '.number_format($totalExpenses)),
+            Stat::make('Estimated Disposable Income', $symbol.' '.number_format($disposableIncome)),
         ];
     }
 }

--- a/app/Filament/Widgets/RecurringCashFlowOverviewWidget.php
+++ b/app/Filament/Widgets/RecurringCashFlowOverviewWidget.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Services\RecurringCashFlowService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class RecurringCashFlowOverviewWidget extends BaseWidget
+{
+    protected function getStats(): array
+    {
+        $startDate = today();
+        $endDate = today()->addYear();
+
+        $totalIncomes = RecurringCashFlowService::processRecurringIncomes(
+            auth()->user(),
+            $startDate,
+            $endDate
+        );
+
+        $totalExpenses = RecurringCashFlowService::processRecurringExpenses(
+            auth()->user(),
+            $startDate,
+            $endDate
+        );
+
+        $disposableIncome = $totalIncomes - $totalExpenses;
+
+        return [
+            Stat::make('Total Estimated Incomes', number_format($totalIncomes)),
+            Stat::make('Total Estimated Expenses', number_format($totalExpenses)),
+            Stat::make('Estimated Disposable Income', number_format($disposableIncome)),
+        ];
+    }
+}

--- a/app/Services/RecurringCashFlowService.php
+++ b/app/Services/RecurringCashFlowService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\RecurringExpense;
+use App\Models\RecurringIncome;
+use App\Models\User;
+use Carbon\Carbon;
+
+class RecurringCashFlowService
+{
+    public static function processRecurringIncomes(User $user, Carbon $startDate, Carbon $endDate): float
+    {
+        return RecurringIncome::query()
+            ->where('user_id', $user->id)
+            ->whereDate('next_transaction_at', '>=', $startDate)
+            ->whereDate('next_transaction_at', '<=', $endDate)
+            ->get()
+            ->reduce(function (?float $carry, RecurringIncome $recurringIncome) use ($endDate) {
+                $count = $recurringIncome->frequency->getRemainingIterations(
+                    $recurringIncome->next_transaction_at,
+                    $endDate,
+                    $recurringIncome->remaining_recurrences
+                );
+
+                return $carry + $count * $recurringIncome->amount;
+            });
+    }
+
+    public static function processRecurringExpenses(User $user, Carbon $startDate, Carbon $endDate): float
+    {
+        return RecurringExpense::query()
+            ->where('user_id', $user->id)
+            ->whereDate('next_transaction_at', '>=', $startDate)
+            ->whereDate('next_transaction_at', '<=', $endDate)
+            ->get()
+            ->reduce(function (?float $carry, RecurringExpense $recurringExpense) use ($endDate) {
+                $count = $recurringExpense->frequency->getRemainingIterations(
+                    $recurringExpense->next_transaction_at,
+                    $endDate,
+                    $recurringExpense->remaining_recurrences
+                );
+
+                return $carry + $count * $recurringExpense->amount;
+            });
+    }
+}

--- a/config/penny.php
+++ b/config/penny.php
@@ -2,4 +2,6 @@
 
 return [
     'currency' => env('CURRENCY', 'INR'),
+
+    'currency_symbol' => env('CURRENCY_SYMBOL', '₹'),
 ];

--- a/tests/Feature/RecurringOverviewTest.php
+++ b/tests/Feature/RecurringOverviewTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Filament\Widgets\RecurringCashFlowOverviewWidget;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('redirects root url to admin login', function () {
+    $this->get('/app/recurring/overview')
+        ->assertOk()
+        ->assertSeeLivewire(RecurringCashFlowOverviewWidget::class);
+});

--- a/tests/Feature/RecurringOverviewTest.php
+++ b/tests/Feature/RecurringOverviewTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 });
 
 it('sees recurring cash flow overview widget', function () {
-    $this->get('/app/recurring/overview')
+    $this->get('/app/recurring-overview')
         ->assertOk()
         ->assertSeeLivewire(RecurringCashFlowOverviewWidget::class);
 });

--- a/tests/Feature/RecurringOverviewTest.php
+++ b/tests/Feature/RecurringOverviewTest.php
@@ -11,7 +11,7 @@ beforeEach(function () {
     $this->actingAs($this->user);
 });
 
-it('redirects root url to admin login', function () {
+it('sees recurring cash flow overview widget', function () {
     $this->get('/app/recurring/overview')
         ->assertOk()
         ->assertSeeLivewire(RecurringCashFlowOverviewWidget::class);


### PR DESCRIPTION
We do have data with recurring incomes and expenses. 

Now our scheduled recurring incomes and expenses are not all at the same frequency. There might be some expenses going in every month while some are going yearly. We can safely consider annual figures consolidated to get a pretty good average of annual cashflows and this Widget addition does that.

The currency symbol can be overriden by setting the env value of `CURRENCY_SYMBOL`


<img width="1492" alt="image" src="https://github.com/user-attachments/assets/23bf6df5-7697-45f8-b421-65dd8eab506d" />
