### PR TITLE
fix:  Recurring Overview page 500 error when empty data

### DIFF
--- a/app/Services/RecurringCashFlowService.php
+++ b/app/Services/RecurringCashFlowService.php
@@ -24,7 +24,7 @@ class RecurringCashFlowService
                 );
 
                 return $carry + $count * $recurringIncome->amount;
-            });
+            }, 0);
     }
 
     public static function processRecurringExpenses(User $user, Carbon $startDate, Carbon $endDate): float
@@ -42,6 +42,6 @@ class RecurringCashFlowService
                 );
 
                 return $carry + $count * $recurringExpense->amount;
-            });
+            }, 0);
     }
 }


### PR DESCRIPTION
Added explicit initial values to array_reduce calls in recurring income and expense calculations. This ensures proper handling of empty arrays and prevents potential issues with undefined carry values.