### PR TITLE
chore: recurring transactions with null account

### DIFF
--- a/app/Jobs/TransactRecurringExpenseJob.php
+++ b/app/Jobs/TransactRecurringExpenseJob.php
@@ -27,6 +27,12 @@ class TransactRecurringExpenseJob implements ShouldQueue
                 ->where('frequency', $this->frequency)
                 ->get()
                 ->map(function (RecurringExpense $recurringExpense) use ($fillable) {
+                    $this->processRecurringExpenseState($recurringExpense);
+
+                    if (is_null($recurringExpense->account_id)) {
+                        return;
+                    }
+
                     $data = $recurringExpense->only($fillable);
 
                     $data['transacted_at'] = $recurringExpense->next_transaction_at;
@@ -34,7 +40,6 @@ class TransactRecurringExpenseJob implements ShouldQueue
 
                     $expense->tags()->attach($recurringExpense->tags);
 
-                    $this->processRecurringExpenseState($recurringExpense);
                 });
         });
     }

--- a/app/Jobs/TransactRecurringIncomeJob.php
+++ b/app/Jobs/TransactRecurringIncomeJob.php
@@ -27,6 +27,12 @@ class TransactRecurringIncomeJob implements ShouldQueue
                 ->where('frequency', $this->frequency)
                 ->get()
                 ->map(function (RecurringIncome $recurringIncome) use ($fillable) {
+                    $this->processRecurringIncomeState($recurringIncome);
+
+                    if (is_null($recurringIncome->account_id)) {
+                        return;
+                    }
+
                     $data = $recurringIncome->only($fillable);
 
                     $data['transacted_at'] = $recurringIncome->next_transaction_at;
@@ -34,7 +40,6 @@ class TransactRecurringIncomeJob implements ShouldQueue
 
                     $income->tags()->attach($recurringIncome->tags);
 
-                    $this->processRecurringIncomeState($recurringIncome);
                 });
         });
     }

--- a/database/factories/RecurringExpenseFactory.php
+++ b/database/factories/RecurringExpenseFactory.php
@@ -39,4 +39,11 @@ class RecurringExpenseFactory extends Factory
             'remaining_recurrences' => null,
         ]);
     }
+
+    public function withoutAccount(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'account_id' => null,
+        ]);
+    }
 }

--- a/database/factories/RecurringIncomeFactory.php
+++ b/database/factories/RecurringIncomeFactory.php
@@ -39,4 +39,11 @@ class RecurringIncomeFactory extends Factory
             'remaining_recurrences' => null,
         ]);
     }
+
+    public function withoutAccount(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'account_id' => null,
+        ]);
+    }
 }

--- a/database/migrations/2024_09_22_145713_create_recurring_incomes_table.php
+++ b/database/migrations/2024_09_22_145713_create_recurring_incomes_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignIdFor(User::class)->constrained();
             $table->foreignIdFor(Person::class)->nullable();
-            $table->foreignIdFor(Account::class)->constrained();
+            $table->foreignIdFor(Account::class)->nullable()->constrained();
             $table->foreignId('category_id')->nullable();
             $table->string('description');
             $table->decimal('amount', 65, 2);

--- a/database/migrations/2024_09_23_170417_create_recurring_expenses_table.php
+++ b/database/migrations/2024_09_23_170417_create_recurring_expenses_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignIdFor(User::class)->constrained();
             $table->foreignIdFor(Person::class)->nullable();
-            $table->foreignIdFor(Account::class)->constrained();
+            $table->foreignIdFor(Account::class)->nullable()->constrained();
             $table->foreignId('category_id')->nullable();
             $table->string('description');
             $table->decimal('amount', 65, 2);

--- a/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
+++ b/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
@@ -32,7 +32,9 @@ test('it copies recurring expense into expense', function () {
 });
 
 test('it does not copy recurring expense into expense when account null', function () {
-    $recurringExpense = RecurringExpense::factory()->withoutAccount()->create();
+    $recurringExpense = RecurringExpense::factory()->withoutAccount()->create([
+        'remaining_recurrences' => 2,
+    ]);
 
     (new TransactRecurringExpenseJob($recurringExpense->frequency))->handle();
 

--- a/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
+++ b/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
@@ -8,6 +8,7 @@ use App\Models\RecurringExpense;
 use App\Models\Tag;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
+use function Pest\Laravel\assertDatabaseEmpty;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\assertDatabaseMissing;
 use function PHPUnit\Framework\assertEquals;
@@ -28,6 +29,18 @@ test('it copies recurring expense into expense', function () {
         'user_id' => $recurringExpense->user_id,
         'transacted_at' => $recurringExpense->next_transaction_at,
     ]);
+});
+
+test('it does not copy recurring expense into expense when account null', function () {
+    $recurringExpense = RecurringExpense::factory()->withoutAccount()->create();
+
+    (new TransactRecurringExpenseJob($recurringExpense->frequency))->handle();
+
+    assertDatabaseEmpty(Expense::class);
+
+    $recurringExpense->refresh();
+
+    assertEquals(1, $recurringExpense->remaining_recurrences);
 });
 
 test('it copies recurring expense tags to expense', function () {


### PR DESCRIPTION
This change allows the user to add recurring transactions but not make the insert into the actual transactions (incomes/expenses) table, This way we can calculate projected estimates without having accidentally triggering these CRONs