### PR TITLE
chore: Simplify instantiation of job classes in tests

### DIFF
--- a/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
+++ b/tests/Feature/Jobs/TransactRecurringExpenseJobTest.php
@@ -18,7 +18,7 @@ uses(DatabaseMigrations::class);
 test('it copies recurring expense into expense', function () {
     $recurringExpense = RecurringExpense::factory()->create();
 
-    (new TransactRecurringExpenseJob($recurringExpense->frequency))->handle();
+    new TransactRecurringExpenseJob($recurringExpense->frequency)->handle();
 
     assertDatabaseHas(Expense::class, [
         'description' => $recurringExpense->description,
@@ -36,7 +36,7 @@ test('it does not copy recurring expense into expense when account null', functi
         'remaining_recurrences' => 2,
     ]);
 
-    (new TransactRecurringExpenseJob($recurringExpense->frequency))->handle();
+    new TransactRecurringExpenseJob($recurringExpense->frequency)->handle();
 
     assertDatabaseEmpty(Expense::class);
 
@@ -51,7 +51,7 @@ test('it copies recurring expense tags to expense', function () {
     $recurringExpense = RecurringExpense::factory()->create();
     $recurringExpense->tags()->attach($tags);
 
-    (new TransactRecurringExpenseJob($recurringExpense->frequency))->handle();
+    new TransactRecurringExpenseJob($recurringExpense->frequency)->handle();
 
     $expenseTags = Expense::first()->tags->pluck('id')->toArray();
 

--- a/tests/Feature/Jobs/TransactRecurringIncomeJobTest.php
+++ b/tests/Feature/Jobs/TransactRecurringIncomeJobTest.php
@@ -18,7 +18,7 @@ uses(DatabaseMigrations::class);
 test('it copies recurring income into income', function () {
     $recurringIncome = RecurringIncome::factory()->create();
 
-    (new TransactRecurringIncomeJob($recurringIncome->frequency))->handle();
+    new TransactRecurringIncomeJob($recurringIncome->frequency)->handle();
 
     assertDatabaseHas(Income::class, [
         'description' => $recurringIncome->description,
@@ -36,7 +36,7 @@ test('it does not copy recurring income into income when account null', function
         'remaining_recurrences' => 2,
     ]);
 
-    (new TransactRecurringIncomeJob($recurringIncome->frequency))->handle();
+    new TransactRecurringIncomeJob($recurringIncome->frequency)->handle();
 
     assertDatabaseEmpty(Income::class);
 
@@ -51,7 +51,7 @@ test('it copies recurring income tags to income', function () {
     $recurringIncome = RecurringIncome::factory()->create();
     $recurringIncome->tags()->attach($tags);
 
-    (new TransactRecurringIncomeJob($recurringIncome->frequency))->handle();
+    new TransactRecurringIncomeJob($recurringIncome->frequency)->handle();
 
     $incomeTags = Income::first()->tags->pluck('id')->toArray();
 

--- a/tests/Feature/Jobs/TransactRecurringTransferJobTest.php
+++ b/tests/Feature/Jobs/TransactRecurringTransferJobTest.php
@@ -17,7 +17,7 @@ uses(DatabaseMigrations::class);
 test('it copies recurring transfer into transfer', function () {
     $recurringTransfer = RecurringTransfer::factory()->create();
 
-    (new TransactRecurringTransferJob($recurringTransfer->frequency))->handle();
+    new TransactRecurringTransferJob($recurringTransfer->frequency)->handle();
 
     assertDatabaseHas(Transfer::class, [
         'description' => $recurringTransfer->description,
@@ -35,7 +35,7 @@ test('it copies recurring transfer tags to transfer', function () {
     $recurringTransfer = RecurringTransfer::factory()->create();
     $recurringTransfer->tags()->attach($tags);
 
-    (new TransactRecurringTransferJob($recurringTransfer->frequency))->handle();
+    new TransactRecurringTransferJob($recurringTransfer->frequency)->handle();
 
     $transferTags = Transfer::first()->tags->pluck('id')->toArray();
 


### PR DESCRIPTION
Replaced redundant parentheses wrapping job class instantiations with direct instantiation in recurring income, transfer, and expense tests. This improves code readability and adheres to common coding conventions.