### PR TITLE
Feat: Set paginated to false in AccountResource table configuration

### DIFF
--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -97,6 +97,7 @@ class AccountResource extends Resource
                             ->toArray(),
                     ),
             ])
+            ->paginated(false)
             ->actions([
                 EditAction::make(),
                 DeleteAction::make(),


### PR DESCRIPTION
Disabled table pagination to display all records in a single view. This enhances usability for scenarios requiring full data visibility without navigating through pages.