### PR TITLE
Fix: Update key mapping for AccountType options in AccountResource

### DIFF
--- a/app/Filament/Resources/AccountResource.php
+++ b/app/Filament/Resources/AccountResource.php
@@ -92,7 +92,7 @@ class AccountResource extends Resource
                     ->multiple()
                     ->options(
                         collect(AccountType::cases())
-                            ->keyBy(fn (AccountType $type) => $type->getLabel())
+                            ->keyBy(fn (AccountType $type) => $type->value)
                             ->map(fn (AccountType $type) => $type->getLabel())
                             ->toArray(),
                     ),


### PR DESCRIPTION
Replaced the keying mechanism to use `AccountType::value` instead of `AccountType::getLabel()` for improved consistency and clarity. This ensures the keys align with the underlying enum values.