### PR TITLE
Fix: Add replicate action visibility for income, expense, and transfer

### DIFF
--- a/app/Filament/Concerns/IncomeExpenseResourceTrait.php
+++ b/app/Filament/Concerns/IncomeExpenseResourceTrait.php
@@ -155,6 +155,7 @@ trait IncomeExpenseResourceTrait
             ->defaultSort('transacted_at', 'desc')
             ->actions([
                 ReplicateAction::make()
+                    ->visible(PanelId::APP->isCurrentPanel())
                     ->formData([
                         'transacted_at' => now(),
                     ]),

--- a/app/Filament/Resources/TransferResource.php
+++ b/app/Filament/Resources/TransferResource.php
@@ -142,6 +142,7 @@ class TransferResource extends Resource
             ->defaultSort('transacted_at', 'desc')
             ->actions([
                 ReplicateAction::make()
+                    ->visible(PanelId::APP->isCurrentPanel())
                     ->formData([
                         'transacted_at' => now(),
                     ]),

--- a/tests/Feature/Expense/ExpenseFamilyViewTest.php
+++ b/tests/Feature/Expense/ExpenseFamilyViewTest.php
@@ -34,6 +34,11 @@ it('cannot display create action', function () {
         ->assertActionHidden('create');
 });
 
+it('cannot display replicate action', function () {
+    livewire(ListExpenses::class)
+        ->assertTableActionHidden('replicate', $this->expense->id);
+});
+
 it('cannot display edit action', function () {
     livewire(ListExpenses::class)
         ->assertTableActionHidden('edit', $this->expense->id);

--- a/tests/Feature/Expense/ExpenseIndividualViewTest.php
+++ b/tests/Feature/Expense/ExpenseIndividualViewTest.php
@@ -28,6 +28,11 @@ it('can display create action', function () {
         ->assertActionVisible('create');
 });
 
+it('can display replicate action', function () {
+    livewire(ListExpenses::class)
+        ->assertTableActionVisible('replicate', $this->expense->id);
+});
+
 it('can display edit action', function () {
     livewire(ListExpenses::class)
         ->assertTableActionVisible('edit', $this->expense->id);

--- a/tests/Feature/Income/IncomeFamilyViewTest.php
+++ b/tests/Feature/Income/IncomeFamilyViewTest.php
@@ -34,6 +34,11 @@ it('cannot display create action', function () {
         ->assertActionHidden('create');
 });
 
+it('cannot display replicate action', function () {
+    livewire(ListIncomes::class)
+        ->assertTableActionHidden('replicate', $this->income->id);
+});
+
 it('cannot display edit action', function () {
     livewire(ListIncomes::class)
         ->assertTableActionHidden('edit', $this->income->id);

--- a/tests/Feature/Income/IncomeIndividualViewTest.php
+++ b/tests/Feature/Income/IncomeIndividualViewTest.php
@@ -28,6 +28,11 @@ it('can display create action', function () {
         ->assertActionVisible('create');
 });
 
+it('can display replicate action', function () {
+    livewire(ListIncomes::class)
+        ->assertTableActionVisible('replicate', $this->income->id);
+});
+
 it('can display edit action', function () {
     livewire(ListIncomes::class)
         ->assertTableActionVisible('edit', $this->income->id);

--- a/tests/Feature/Transfer/TransferFamilyViewTest.php
+++ b/tests/Feature/Transfer/TransferFamilyViewTest.php
@@ -27,6 +27,11 @@ it('cannot display create action', function () {
         ->assertActionHidden('create');
 });
 
+it('cannot display replicate action', function () {
+    livewire(ListTransfers::class)
+        ->assertTableActionHidden('replicate', $this->transfer->id);
+});
+
 it('cannot display edit action', function () {
     livewire(ListTransfers::class)
         ->assertTableActionHidden('edit', $this->transfer->id);

--- a/tests/Feature/Transfer/TransferIndividualViewTest.php
+++ b/tests/Feature/Transfer/TransferIndividualViewTest.php
@@ -26,6 +26,11 @@ it('can display create action', function () {
         ->assertActionVisible('create');
 });
 
+it('can display replicate action', function () {
+    livewire(ListTransfers::class)
+        ->assertTableActionVisible('replicate', $this->transfer->id);
+});
+
 it('can display edit action', function () {
     livewire(ListTransfers::class)
         ->assertTableActionVisible('edit', $this->transfer->id);


### PR DESCRIPTION
Implemented the visibility logic for the replicate action based on panel context. Added corresponding tests to ensure correct visibility in various views (individual and family) for income, expense, and transfer entities.